### PR TITLE
Fatal Error paiement décliné

### DIFF
--- a/Controller/Redirect/Decline.php
+++ b/Controller/Redirect/Decline.php
@@ -83,25 +83,25 @@ class Decline extends Fullservice
             $order->getResource()->load($order, $lastOrderId);
             if ($order && (bool)$order->getPayment()->getMethodInstance()->getConfigData('re_add_to_cart')) {
                 /** @var $cart \Magento\Checkout\Model\Cart **/
-                $cart = $this->_objectManager->get('Magento\Checkout\Model\Cart');
+                $cart  = $this->_objectManager->get('Magento\Checkout\Model\Cart');
                 $items = $order->getItemsCollection();
-                foreach ($items as $item) {
-                    try {
+                try {
+                    foreach ($items as $item) {
                         $cart->addOrderItem($item);
-
-                        $cart->save();
-                    } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                        if ($this->_objectManager->get('Magento\Checkout\Model\Session')->getUseNotice(true)) {
-                            $this->messageManager->addNotice($e->getMessage());
-                        } else {
-                            $this->messageManager->addError($e->getMessage());
-                        }
-                    } catch (\Exception $e) {
-                        $this->messageManager->addException(
-                            $e,
-                            __('We can\'t add this item to your shopping cart right now.')
-                        );
                     }
+
+                    $cart->save();
+                } catch (\Magento\Framework\Exception\LocalizedException $e) {
+                    if ($this->_objectManager->get('Magento\Checkout\Model\Session')->getUseNotice(true)) {
+                        $this->messageManager->addNotice($e->getMessage());
+                    } else {
+                        $this->messageManager->addError($e->getMessage());
+                    }
+                } catch (\Exception $e) {
+                    $this->messageManager->addException(
+                        $e,
+                        __('We can\'t add this item to your shopping cart right now.')
+                    );
                 }
             }
         }

--- a/Controller/Redirect/Decline.php
+++ b/Controller/Redirect/Decline.php
@@ -88,6 +88,8 @@ class Decline extends Fullservice
                 foreach ($items as $item) {
                     try {
                         $cart->addOrderItem($item);
+
+                        $cart->save();
                     } catch (\Magento\Framework\Exception\LocalizedException $e) {
                         if ($this->_objectManager->get('Magento\Checkout\Model\Session')->getUseNotice(true)) {
                             $this->messageManager->addNotice($e->getMessage());
@@ -101,8 +103,6 @@ class Decline extends Fullservice
                         );
                     }
                 }
-
-                $cart->save();
             }
         }
         //MO/TO case


### PR DESCRIPTION
### Prérequis
1. Module `hipay/hipay-fullservice-sdk-magento2 >= 13.3` (non testé sous cette version)

### Étapes pour reproduire

1. Créer un produit configurable avec une quantité de "1" (seul pour passer en épuisé définie à 0)
2. Ajouter ce produit configurable au panier
3. Passer commande
4. Obtenir un refus de paiement (en mode test, le produit doit avoir un prix de 13,04€ pour être automatiquement refusé)

### Résultat attendu
1. Redirection vers la page de paiement refusé (`/checkout/onepage/failure/`) avec message d'erreur

### Résultat obtenu
1. Page de maintenance
2. Logs d'exception dans le fichier `system.log` avec le report suivant :

```
==> var/log/system.log <==
[2021-12-06 09:26:40] main.CRITICAL: Exception message: SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`magento2`.`quote_item_option`, CONSTRAINT `QUOTE_ITEM_OPTION_ITEM_ID_QUOTE_ITEM_ITEM_ID` FOREIGN KEY (`item_id`) REFERENCES `quote_item` (`item_id`) ON DELETE CASCADE), query was: INSERT INTO `quote_item_option` (`product_id`, `code`, `value`) VALUES (?, ?, ?)
Trace: <pre>#1 Magento\Framework\DB\Statement\Pdo\Mysql->_execute() called at [vendor/magento/zendframework1/library/Zend/Db/Statement.php:303]
#2 Zend_Db_Statement->execute() called at [vendor/magento/zendframework1/library/Zend/Db/Adapter/Abstract.php:480]
#3 Zend_Db_Adapter_Abstract->query() called at [vendor/magento/zendframework1/library/Zend/Db/Adapter/Pdo/Abstract.php:238]
#4 Zend_Db_Adapter_Pdo_Abstract->query() called at [vendor/magento/framework/DB/Adapter/Pdo/Mysql.php:546]
#5 Magento\Framework\DB\Adapter\Pdo\Mysql->_query() called at [vendor/magento/framework/DB/Adapter/Pdo/Mysql.php:613]
#6 Magento\Framework\DB\Adapter\Pdo\Mysql->query() called at [generated/code/Magento/Framework/DB/Adapter/Pdo/Mysql/Interceptor.php:128]
#7 Magento\Framework\DB\Adapter\Pdo\Mysql\Interceptor->query() called at [vendor/magento/zendframework1/library/Zend/Db/Adapter/Abstract.php:576]
#8 Zend_Db_Adapter_Abstract->insert() called at [generated/code/Magento/Framework/DB/Adapter/Pdo/Mysql/Interceptor.php:1506]
#9 Magento\Framework\DB\Adapter\Pdo\Mysql\Interceptor->insert() called at [vendor/magento/framework/Model/ResourceModel/Db/AbstractDb.php:781]
#10 Magento\Framework\Model\ResourceModel\Db\AbstractDb->saveNewObject() called at [vendor/magento/framework/Model/ResourceModel/Db/AbstractDb.php:421]
#11 Magento\Framework\Model\ResourceModel\Db\AbstractDb->save() called at [vendor/magento/framework/Model/AbstractModel.php:655]
#12 Magento\Framework\Model\AbstractModel->save() called at [vendor/magento/module-quote/Model/Quote/Item.php:754]
#13 Magento\Quote\Model\Quote\Item->saveItemOptions() called at [generated/code/Magento/Quote/Model/Quote/Item/Interceptor.php:310]
#14 Magento\Quote\Model\Quote\Item\Interceptor->saveItemOptions() called at [vendor/magento/module-quote/Model/ResourceModel/Quote/Item.php:38]
#15 Magento\Quote\Model\ResourceModel\Quote\Item->save() called at [vendor/magento/framework/Model/AbstractModel.php:655]
#16 Magento\Framework\Model\AbstractModel->save() called at [generated/code/Magento/Quote/Model/Quote/Item/Interceptor.php:1324]
#17 Magento\Quote\Model\Quote\Item\Interceptor->save() called at [vendor/magento/framework/Model/ResourceModel/Db/Collection/AbstractCollection.php:603]
#18 Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection->save() called at [vendor/magento/module-quote/Model/Quote/Relation.php:27]
#19 Magento\Quote\Model\Quote\Relation->processRelation() called at [vendor/magento/framework/Model/ResourceModel/Db/VersionControl/RelationComposite.php:48]
#20 Magento\Framework\Model\ResourceModel\Db\VersionControl\RelationComposite->processRelations() called at [vendor/magento/framework/Model/ResourceModel/Db/VersionControl/AbstractDb.php:57]
#21 Magento\Framework\Model\ResourceModel\Db\VersionControl\AbstractDb->processAfterSaves() called at [vendor/magento/framework/Model/ResourceModel/Db/AbstractDb.php:424]
#22 Magento\Framework\Model\ResourceModel\Db\AbstractDb->save() called at [vendor/magento/module-quote/Model/ResourceModel/Quote.php:307]
#23 Magento\Quote\Model\ResourceModel\Quote->save() called at [vendor/magento/module-quote/Model/QuoteRepository/SaveHandler.php:121]
#24 Magento\Quote\Model\QuoteRepository\SaveHandler->save() called at [vendor/magento/framework/Interception/Interceptor.php:58]
#25 Magento\Quote\Model\QuoteRepository\SaveHandler\Interceptor->___callParent() called at [vendor/magento/framework/Interception/Interceptor.php:138]
#26 Magento\Quote\Model\QuoteRepository\SaveHandler\Interceptor->Magento\Framework\Interception\{closure}() called at [vendor/magento/framework/Interception/Interceptor.php:153]
#27 Magento\Quote\Model\QuoteRepository\SaveHandler\Interceptor->___callPlugins() called at [generated/code/Magento/Quote/Model/QuoteRepository/SaveHandler/Interceptor.php:26]
#28 Magento\Quote\Model\QuoteRepository\SaveHandler\Interceptor->save() called at [vendor/magento/module-quote/Model/QuoteRepository.php:196]
#29 Magento\Quote\Model\QuoteRepository->save() called at [vendor/magento/framework/Interception/Interceptor.php:58]
#30 Magento\Quote\Model\QuoteRepository\Interceptor->___callParent() called at [vendor/magento/framework/Interception/Interceptor.php:138]
#31 Magento\Quote\Model\QuoteRepository\Interceptor->Magento\Framework\Interception\{closure}() called at [vendor/magento/framework/Interception/Interceptor.php:153]
#32 Magento\Quote\Model\QuoteRepository\Interceptor->___callPlugins() called at [generated/code/Magento/Quote/Model/QuoteRepository/Interceptor.php:78]
#33 Magento\Quote\Model\QuoteRepository\Interceptor->save() called at [vendor/magento/module-checkout/Model/Cart.php:581]
#34 Magento\Checkout\Model\Cart->save() called at [vendor/magento/framework/Interception/Interceptor.php:58]
#35 Magento\Checkout\Model\Cart\Interceptor->___callParent() called at [vendor/magento/framework/Interception/Interceptor.php:138]
#36 Magento\Checkout\Model\Cart\Interceptor->Magento\Framework\Interception\{closure}() called at [vendor/magento/framework/Interception/Interceptor.php:153]
#37 Magento\Checkout\Model\Cart\Interceptor->___callPlugins() called at [generated/code/Magento/Checkout/Model/Cart/Interceptor.php:182]
#38 Magento\Checkout\Model\Cart\Interceptor->save() called at [vendor/hipay/hipay-fullservice-sdk-magento2/Controller/Redirect/Decline.php:92]
#39 HiPay\FullserviceMagento\Controller\Redirect\Decline->execute() called at [generated/code/HiPay/FullserviceMagento/Controller/Redirect/Decline/Interceptor.php:24]
#40 HiPay\FullserviceMagento\Controller\Redirect\Decline\Interceptor->execute() called at [vendor/magento/framework/App/Action/Action.php:108]
#41 Magento\Framework\App\Action\Action->dispatch() called at [vendor/magento/framework/Interception/Interceptor.php:58]
#42 HiPay\FullserviceMagento\Controller\Redirect\Decline\Interceptor->___callParent() called at [vendor/magento/framework/Interception/Interceptor.php:138]
#43 HiPay\FullserviceMagento\Controller\Redirect\Decline\Interceptor->Magento\Framework\Interception\{closure}() called at [app/code/Anowave/Ec/Plugin/App/Action/Context.php:148]
#44 Anowave\Ec\Plugin\App\Action\Context->aroundDispatch() called at [vendor/magento/framework/Interception/Interceptor.php:135]
#45 HiPay\FullserviceMagento\Controller\Redirect\Decline\Interceptor->Magento\Framework\Interception\{closure}() called at [vendor/magento/framework/Interception/Interceptor.php:153]
#46 HiPay\FullserviceMagento\Controller\Redirect\Decline\Interceptor->___callPlugins() called at [generated/code/HiPay/FullserviceMagento/Controller/Redirect/Decline/Interceptor.php:65]
#47 HiPay\FullserviceMagento\Controller\Redirect\Decline\Interceptor->dispatch() called at [vendor/magento/framework/App/FrontController.php:162]
#48 Magento\Framework\App\FrontController->processRequest() called at [vendor/magento/framework/App/FrontController.php:98]
#49 Magento\Framework\App\FrontController->dispatch() called at [vendor/magento/framework/Interception/Interceptor.php:58]
#50 Magento\Framework\App\FrontController\Interceptor->___callParent() called at [vendor/magento/framework/Interception/Interceptor.php:138]
#51 Magento\Framework\App\FrontController\Interceptor->Magento\Framework\Interception\{closure}() called at [vendor/magento/module-store/App/FrontController/Plugin/RequestPreprocessor.php:99]
#52 Magento\Store\App\FrontController\Plugin\RequestPreprocessor->aroundDispatch() called at [vendor/magento/framework/Interception/Interceptor.php:135]
#53 Magento\Framework\App\FrontController\Interceptor->Magento\Framework\Interception\{closure}() called at [vendor/magento/module-page-cache/Model/App/FrontController/BuiltinPlugin.php:69]
#54 Magento\PageCache\Model\App\FrontController\BuiltinPlugin->aroundDispatch() called at [vendor/magento/framework/Interception/Interceptor.php:135]
#55 Magento\Framework\App\FrontController\Interceptor->Magento\Framework\Interception\{closure}() called at [vendor/magento/framework/Interception/Interceptor.php:153]
#56 Magento\Framework\App\FrontController\Interceptor->___callPlugins() called at [generated/code/Magento/Framework/App/FrontController/Interceptor.php:26]
#57 Magento\Framework\App\FrontController\Interceptor->dispatch() called at [vendor/magento/framework/App/Http.php:116]
#58 Magento\Framework\App\Http->launch() called at [generated/code/Magento/Framework/App/Http/Interceptor.php:24]
#59 Magento\Framework\App\Http\Interceptor->launch() called at [vendor/magento/framework/App/Bootstrap.php:261]
#60 Magento\Framework\App\Bootstrap->run() called at [pub/index.php:84]
</pre> [] []
```

---


Cette pull request a donc pour objecit de déplacer la sauvegarde de l'objet `$cart` dans le bloc `try {...} catch(...) { ...}` pour ne plus déclencher cette erreur.

Aussi, y a-t-il une raison derrière l'utilisation de l'Object Manager à la ligne 86 (`$cart = $this->_objectManager->get('Magento\Checkout\Model\Cart');`) et non pas une dépendance d'injection ?